### PR TITLE
allow optional .data field in error

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,8 @@ module.exports = userConfig => {
       if (isFunction(config.onError)) config.onError(err, body)
       const error = {
         code: Number(err.code || err.status || INTERNAL_ERROR.code),
-        message: err.message || INTERNAL_ERROR.message
+        message: err.message || INTERNAL_ERROR.message,
+        data: err.data
       }
       return { jsonrpc, error, id: id || null }
     }


### PR DESCRIPTION
JSON RPC allows .data field in error object:
```
data
A Primitive or Structured value that contains additional information about the error.
This may be omitted.
The value of this member is defined by the Server (e.g. detailed error information, nested errors etc.).
```